### PR TITLE
construct data as powershell object for proper indentation

### DIFF
--- a/plugins/vscode/vscode-models-downloads.ps1
+++ b/plugins/vscode/vscode-models-downloads.ps1
@@ -1,4 +1,4 @@
-# see https://github.com/MicrosoftDocs/intellicode/issues/4#issuecomment-450935237 and https://github.com/MicrosoftDocs/intellicode/issues/4
+﻿# see https://github.com/MicrosoftDocs/intellicode/issues/4#issuecomment-450935237 and https://github.com/MicrosoftDocs/intellicode/issues/4
 
 param ($username, $version)
 
@@ -11,9 +11,7 @@ $toJsonArray= @()
 
 # # For each application
 Get-Content .\vscode-models.txt | ForEach-Object {
-    $model=$_ -split ' '
-    $language=$model[0]
-    $url=$model[1]
+    $language, $url = $_ -split ' '
 
     $result=curl -s -XGET $url
 
@@ -25,23 +23,18 @@ Get-Content .\vscode-models.txt | ForEach-Object {
 
     $filename="$($modelId)_$($id)"
 
-# # here-string don't like white-spaces so we can't indent here
-$json= @"
-{
-    "analyzerName": "intellisense-members",
-    "languageName": "$language",
-    "identity": {
-        "modelId": "$modelId",
-        "outputId": "$id",
-        "modifiedTimeUtc": "$updated"
-    },
-    "filePath": "c:\\Users\\$username\\.vscode\\extensions\\visualstudioexptteam.vscodeintellicode-$version\\cache\\$filename",
-    "lastAccessTimeUtc": "2022-06-29T16:49:32.785Z"
-}
-"@
-
-# append to the array
-$toJsonArray += ConvertFrom-Json $json
+    # append to the array
+    $toJsonArray += [PSCustomObject]@{
+        'analyzerName' = "intellisense-members"
+        'languageName' = "$language"
+        'identity' = [PSCustomObject]@{
+            'modelId' = "$modelId"
+            'outputId' = "$id"
+            'modifiedTimeUtc' = "$updated"
+        }
+        'filePath' = "c:\Users\$username\.vscode\extensions\visualstudioexptteam.vscodeintellicode-$version\cache\$filename"
+        'lastAccessTimeUtc' = "2022-06-29T16:49:32.785Z"
+    }
 
     Write-Host "Starting download for $language"
     # -L: follow redirect

--- a/plugins/vscode/vscode-plugin-downloads.ps1
+++ b/plugins/vscode/vscode-plugin-downloads.ps1
@@ -1,4 +1,4 @@
-# credits to https://github.com/deskoh/download-scripts/blob/main/vscode-visx.sh for the marketplace API
+﻿# credits to https://github.com/deskoh/download-scripts/blob/main/vscode-visx.sh for the marketplace API
 
 # to sort
 # Get-Content .\vscode-plugins.txt | sort | get-unique | Set-Content vscode-plugins.txt
@@ -15,28 +15,25 @@ $url="https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery"
 Get-Content .\vscode-plugins.txt | ForEach-Object {
     $plugin=$_
 
-# For some unknown reason, quote must be escape before passing to curl
-$data_binary=@"
-{
-    \"assetTypes\": [\"Microsoft.VisualStudio.Services.VSIXPackage\"],
-    \"filters\": [
-        {
-            \"criteria\": [
-                {
-                    \"filterType\": 7,
-                    \"value\": \"$plugin\"
-                }
-            ]
-        }
-    ],
-    \"flags\": 3
-}
-"@
+    $data_binary = ConvertTo-Json -Depth 10 -Compress -InputObject @{
+        "assetTypes" = @("Microsoft.VisualStudio.Services.VSIXPackage")
+        "filters" = @(
+            @{
+                "criteria" = @(
+                    @{
+                        "filterType" = 7
+                        "value" = "$plugin"
+                    }
+                )
+            }
+        )
+        "flags" = 3
+    }
 
     Write-Host "Starting download for $plugin"
 
     # make post request to vscode marketplace
-    $result=curl -s -XPOST $url --header $header_accept --header $header_content_type --data-raw $data_binary
+    $result="$data_binary" | curl -s -XPOST $url --header $header_accept --header $header_content_type --data '@-'
 
     # parse the result
     # $extension_name=$result | jq -r '.results[0].extensions[0].extensionName'

--- a/winget/winget-downloads.ps1
+++ b/winget/winget-downloads.ps1
@@ -16,16 +16,15 @@ Get-Content .\winget-applications.txt | ForEach-Object {
     $manifest=winget show $application
 
     # manifest to extract
-    $extract_version="Version: "
-    $extract_url="Download Url: "
+    $extract_version="(?<=Version:).*"
+    $extract_url='(?<=Download Url:|Installer Url:).*'
 
     # using the manifest object
-    # filter it to just version row
-    # convert from object into string for manipulation
-    # trim the string
-    # extract just the value for version / url
-    $version=$manifest | Select-String $extract_version -NoEmphasis | Out-String | ForEach-Object { $_.Trim() } | ForEach-Object { $_.SubString($extract_version.Length) }
-    $url=$manifest | Select-String $extract_url -NoEmphasis | Out-String | ForEach-Object { $_.Trim() } | ForEach-Object { $_.SubString($extract_url.Length) }
+    # find the version row and match what comes after it
+    # get the matched string value from the regex
+    # trim it to remove whitespace and get just the version / url
+    $version=$manifest | Select-String -Pattern $extract_version | Select-Object -ExpandProperty Matches | Select-Object -ExpandProperty Value | ForEach-Object Trim
+    $url=$manifest | Select-String -Pattern $extract_url | Select-Object -ExpandProperty Matches | Select-Object -ExpandProperty Value | ForEach-Object Trim
 
     # what we can do with the json is to use it for the next run where
     # we don't download version that was not updated to save bandwidth and unnecessary downloads

--- a/winget/winget-downloads.ps1
+++ b/winget/winget-downloads.ps1
@@ -1,4 +1,4 @@
-# to sort
+﻿# to sort
 # Get-Content .\winget-applications.txt | sort | get-unique | Set-Content winget-applications.txt
 
 Write-Host "Starting..."
@@ -27,20 +27,16 @@ Get-Content .\winget-applications.txt | ForEach-Object {
     $version=$manifest | Select-String $extract_version -NoEmphasis | Out-String | ForEach-Object { $_.Trim() } | ForEach-Object { $_.SubString($extract_version.Length) }
     $url=$manifest | Select-String $extract_url -NoEmphasis | Out-String | ForEach-Object { $_.Trim() } | ForEach-Object { $_.SubString($extract_url.Length) }
 
-# here-string don't like white-spaces so we can't indent here
-$json= @"
-{
-    "id": "$application",
-    "application": "$application",
-    "version": "$version",
-    "download_url": "$url"
-}
-"@
-# what we can do with the json is to use it for the next run where
-# we don't download version that was not updated to save bandwidth and unnecessary downloads
+    # what we can do with the json is to use it for the next run where
+    # we don't download version that was not updated to save bandwidth and unnecessary downloads
 
-# append to the array
-$toJsonArray += ConvertFrom-Json $json
+    # append to the array
+    $toJsonArray += [PSCustomObject]@{
+        'id'           = "$application"
+        'application'  = "$application"
+        'version'      = "$version"
+        'download_url' = "$url"
+    }
 
     Write-Host "Starting download for $application"
     # -L: follow redirect


### PR DESCRIPTION
this also removes the need for the extra step of `ConvertFrom-Json`-ing the here-string because the data is created right away as PowerShell objects.

The results the changed code produces are identical to before